### PR TITLE
Pin caproto requirement to separate experimental depencies.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 codecov
 coveralls
+caproto[standard] >=0.4.2rc1
 matplotlib
 pytest >=3.6
 pytest-cov


### PR DESCRIPTION
Back-port of #769.